### PR TITLE
do not send NAN/unknown on invalid stove reply

### DIFF
--- a/components/micronova/number/micronova_number.cpp
+++ b/components/micronova/number/micronova_number.cpp
@@ -7,7 +7,6 @@ void MicroNovaNumber::process_value_from_stove(int value_from_stove) {
   float new_sensor_value = 0;
 
   if (value_from_stove == -1) {
-    this->publish_state(NAN);
     return;
   }
 

--- a/components/micronova/sensor/micronova_sensor.cpp
+++ b/components/micronova/sensor/micronova_sensor.cpp
@@ -5,7 +5,6 @@ namespace micronova {
 
 void MicroNovaSensor::process_value_from_stove(int value_from_stove) {
   if (value_from_stove == -1) {
-    this->publish_state(NAN);
     return;
   }
 

--- a/components/micronova/text_sensor/micronova_text_sensor.cpp
+++ b/components/micronova/text_sensor/micronova_text_sensor.cpp
@@ -5,7 +5,6 @@ namespace micronova {
 
 void MicroNovaTextSensor::process_value_from_stove(int value_from_stove) {
   if (value_from_stove == -1) {
-    this->publish_state("unknown");
     return;
   }
 


### PR DESCRIPTION
i noticed that occasionally i get an invalid reply from my stove (likely a timing issue on the reads) which causes the sensor status to be set to NAN, in my case INT32_MAX after casting it to int in a custom text sensor

here is an example:
```
  - platform: template
    name: "Chrono enabled"
    lambda: |-
      if (!id(eeprom_address_0xb8_sensor).has_state() ||
          !id(eeprom_address_0xb9_sensor).has_state() ||
          !id(eeprom_address_0xba_sensor).has_state() ||
          !id(eeprom_address_0xbb_sensor).has_state() ||
          !id(eeprom_address_0xbc_sensor).has_state()) {
        return std::string("unavailable");
      }
      int chrono_feature_enabled = id(eeprom_address_0xb8_sensor).state;
      int chrono1_enabled = id(eeprom_address_0xb9_sensor).state;
      int chrono2_enabled = id(eeprom_address_0xba_sensor).state;
      int chrono3_enabled = id(eeprom_address_0xbb_sensor).state;
      int chrono4_enabled = id(eeprom_address_0xbc_sensor).state;
      if (chrono_feature_enabled == 1) {
        std::string enabled_chronos = "[";
        enabled_chronos += std::to_string(chrono1_enabled);
        enabled_chronos += ", ";
        enabled_chronos += std::to_string(chrono2_enabled);
        enabled_chronos += ", ";
        enabled_chronos += std::to_string(chrono3_enabled);
        enabled_chronos += ", ";
        enabled_chronos += std::to_string(chrono4_enabled);
        enabled_chronos += "]";
        return enabled_chronos;
      } else {
        return std::string("Disabled");
      }
```

when any of the eeprom sensors reports NAN i get INT32_MAX in my string, not setting any state will result in home assistant just keeping its previous state